### PR TITLE
Invite command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,25 +18,18 @@ This bot is open source and supported by the team behind [tarkov.dev](https://ta
 
 ### Commands 💬
 
-`/price` && `!price`
-
-`/map` && `!map`
-
-`/barter` && `!barter`
-
-`/craft` && `!craft`
-
-`/ammo`
-
-`/status`
-
-`/help` && `!help`
-
-`/about`
-
-`/issue`
-
-`/status`
+|  Command  |  Example   |  Description   |
+|    :----:   |     :----:    |        :----:       |
+| `/help`      | `/help` or `help <command>`         | The help command to view all available commands |
+| `/price` | `/price name: <item>`  | Get a detailed output on the price of an item, its price tier, and more! |
+| `/map` | `/map woods` | View a map and some general info about it |
+| `/barter` | `/barter name: <item>` | Check barter details for an item |
+| `/craft` | `/craft name: <item>` | Check crafting details for an item |
+| `/ammo` | `/ammo ammo_type: 5.45x39mm` | Get a sorted ammo table for a certain ammo type |
+| `/status` | - | Get the game/server/website status of Escape from Tarkov |
+| `/about` | - | View details about the bot |
+| `/issue` | `/issue message: <text>` | Report an issue with the bot |
+| `/invite` | - | Get a Discord invite link for the bot to join it to another server |
 
 ---
 

--- a/commands/invite.mjs
+++ b/commands/invite.mjs
@@ -1,0 +1,25 @@
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { MessageEmbed } from 'discord.js';
+// import generalError from '../modules/general-error.mjs';
+
+const BOT_INVITE_LINK = "https://discord.com/api/oauth2/authorize?client_id=955521336904667227&permissions=309237664832&scope=bot%20applications.commands";
+
+const defaultFunction = {
+    data: new SlashCommandBuilder()
+        .setName("invite")
+        .setDescription("Get an invite link to invite the bot to another Discord server"),
+    async execute(interaction) {
+        const embed = new MessageEmbed();
+        embed.setTitle("Stash Invite Link 🔗");
+        embed.setAuthor({
+            name: 'Stash',
+            iconURL: 'https://assets.tarkov.dev/tarkov-dev-icon.png',
+        });
+        embed.setDescription("Click the link above to invite the Stash bot to your Discord server!");
+        embed.setURL(BOT_INVITE_LINK);
+        embed.setFooter({ text: 'Enjoy ❤️' });
+        await interaction.editReply({ embeds: [embed] });
+    },
+};
+
+export default defaultFunction;

--- a/template/template.mjs
+++ b/template/template.mjs
@@ -1,0 +1,18 @@
+// A template file to quickly create a new bot command
+import { SlashCommandBuilder } from "@discordjs/builders";
+import { MessageEmbed } from 'discord.js';
+// import generalError from '../modules/general-error.mjs';
+
+const defaultFunction = {
+    data: new SlashCommandBuilder()
+        .setName("TEMPLATE")
+        .setDescription("TEMPLATE DESCRIPTION"),
+    async execute(interaction) {
+        const embed = new MessageEmbed();
+        embed.setTitle("TEMPLATE TITLE");
+        embed.setDescription("TEMPLATE DESCRIPTION");
+        await interaction.editReply({ embeds: [embed] });
+    },
+};
+
+export default defaultFunction;


### PR DESCRIPTION
This pull request does the following:

- Adds a nice markdown table to view the commands the bot has with examples on the main README
- Adds a template file to quickly create new commands
- Adds a new `/invite` command to get an invite link for the bot to add it to new servers