### PR TITLE
set string options to required

### DIFF
--- a/commands/ammo.mjs
+++ b/commands/ammo.mjs
@@ -41,6 +41,7 @@ const defaultFunction = {
             .setName('ammo_type')
             .setDescription('Enter the ammo type')
             .setChoices(ammoTypes)
+            .setRequired(true)
         ),
     async execute(interaction) {
         let searchString = '';

--- a/commands/barter.mjs
+++ b/commands/barter.mjs
@@ -15,7 +15,8 @@ const defaultFunction = {
         .addStringOption(option => {
             return option.setName('name')
                 .setDescription('Item name to search for')
-                .setAutocomplete(true);
+                .setAutocomplete(true)
+                .setRequired(true);
         }),
     async execute(interaction) {
         const searchString = interaction.options.getString('name');

--- a/commands/craft.mjs
+++ b/commands/craft.mjs
@@ -15,7 +15,8 @@ const defaultFunction = {
         .addStringOption(option => {
             return option.setName('name')
                 .setDescription('Item name to search for')
-                .setAutocomplete(true);
+                .setAutocomplete(true)
+                .setRequired(true);
         }),
     async execute(interaction) {
         const searchString = interaction.options.getString('name');

--- a/commands/issue.mjs
+++ b/commands/issue.mjs
@@ -10,6 +10,7 @@ const defaultFunction = {
             .setRequired(true)
             .setDescription("Enter your message")
             .setName("message")
+            .setRequired(true)
         ),
     async execute(interaction) {
         const { client, member } = interaction;

--- a/commands/map.mjs
+++ b/commands/map.mjs
@@ -12,6 +12,7 @@ const defaultFunction = {
         .addStringOption(option => option
             .setName('maplist')
             .setDescription('Enter a list of maps to include')
+            .setRequired(true)
         ),
     async execute(interaction) {
         const inputMaps = interaction.options.getString('maplist');

--- a/commands/price.mjs
+++ b/commands/price.mjs
@@ -17,7 +17,8 @@ const defaultFunction = {
         .addStringOption(option => {
             return option.setName('name')
                 .setDescription('Item name to search for')
-                .setAutocomplete(true);
+                .setAutocomplete(true)
+                .setRequired(true);
         }),
     async execute(interaction) {
         let searchString = interaction.options.getString('name');


### PR DESCRIPTION
Sets the string option values to
required since these values are required
for the command

The user can access the command quicker as well since they do not need to select the option.

Before the "required" Flag
![Screenshot_1](https://user-images.githubusercontent.com/56650568/160948029-507b1fb8-d1a7-46d6-b596-0b7b7a610804.png)

After the "required" Flag
![Screenshot_2](https://user-images.githubusercontent.com/56650568/160948197-7ec683e2-a306-4323-ac3b-985c72f07c7d.png)
![Screenshot_3](https://user-images.githubusercontent.com/56650568/160948205-d4ba152b-e975-497b-b6df-bf937b021a41.png)


