### PR TITLE
Separate out tools from craft

### DIFF
--- a/commands/ammo.mjs
+++ b/commands/ammo.mjs
@@ -19,6 +19,7 @@ const ammoTypes = [
     ['9x21mm', '9x21mm'],
     ['12/70', '12/70'],
     ['4.6x30mm', '4.6x30mm'],
+    //['.357 Magnum', '.357 Magnum'],
     ['.338 Lapua', '.338 Lapua'],
     ['.300 Blackout', '.300 Blackout'],
     ['.45 ACP', '.45 ACP'],

--- a/commands/craft.mjs
+++ b/commands/craft.mjs
@@ -71,6 +71,9 @@ const defaultFunction = {
             const craft = matchedCrafts[i];
             let totalCost = 0;
             const embed = new MessageEmbed();
+            const toolsEmbed = new MessageEmbed();
+            toolsEmbed.setTitle('Required Tools');
+            let toolCost = 0;
 
             let title = craft.rewardItems[0].item.name;
 
@@ -110,6 +113,21 @@ const defaultFunction = {
                     }
                 }
 
+                let isTool = false;
+                for (let i = 0; i < req.attributes.length; i++) {
+                    if (req.attributes[i].type === 'tool') {
+                        isTool = true;
+                        break;
+                    }
+                }
+                if (isTool) {
+                    toolCost += itemCost * req.count;
+                    toolsEmbed.addField(req.item.name, itemCost.toLocaleString() + "₽ x " + req.count, true);
+                    if(!toolsEmbed.thumbnail) {
+                        toolsEmbed.setThumbnail(req.item.iconLink);
+                    }
+                    continue;
+                }
                 totalCost += itemCost * req.count;
                 //totalCost += req.item.avg24hPrice * req.count;
                 embed.addField(req.item.name, itemCost.toLocaleString() + "₽ x " + req.count, true);
@@ -117,6 +135,10 @@ const defaultFunction = {
             embed.addField("Total", totalCost.toLocaleString() + "₽", true);
 
             embeds.push(embed);
+            if (toolsEmbed.fields.length > 0) {
+                toolsEmbed.addField("Total", toolCost.toLocaleString() + "₽", true);
+                embeds.push(toolsEmbed);
+            }
 
             if (i == MAX_CRAFTS - 1) {
                 break;

--- a/modules/autocomplete.mjs
+++ b/modules/autocomplete.mjs
@@ -1,10 +1,31 @@
 import ttRequest from "./tt-request.mjs";
 
-let nameCache = false;
-let lookupCache = {};
+//let nameCache = false;
+//let lookupCache = {};
+const caches = {
+    default: {
+        nameCache: false,
+        lookupCache: {}
+    },
+    barter: {
+        nameCache: false,
+        lookupCache: {}
+    },
+    craft: {
+        nameCache: false,
+        lookupCache: {}
+    }
+}
 
 async function fillCache() {
-    if (nameCache) {
+    let cacheFilled = true;
+    for (const cacheName in caches) {
+        if (!caches[cacheName].nameCache) {
+            cacheFilled = false;
+            break;
+        }
+    }
+    if (cacheFilled) {
         return true;
     }
 
@@ -19,7 +40,55 @@ async function fillCache() {
             }`
         });
 
-        nameCache = itemNamesResponse.data.itemsByType.map(item => item.name);
+        caches.default.nameCache = itemNamesResponse.data.itemsByType.map(item => item.name);
+
+        const barterResponse = await ttRequest({
+            graphql: `query {
+                barters {
+                    rewardItems {
+                        item {
+                            name
+                        }
+                    }
+                    requiredItems {
+                        item {
+                            name
+                        }
+                    }
+                }
+            }`
+        });
+
+        caches.barter.nameCache = [];
+        barterResponse.data.barters.map(barter => {
+            caches.barter.nameCache = [...new Set([...caches.barter.nameCache, ...[...new Set([...barter.rewardItems.map(item => item.item.name), ...barter.requiredItems.map(item => item.item.name)])]])];
+            return;
+        });
+        caches.barter.nameCache.sort();
+
+        const craftResponse = await ttRequest({
+            graphql: `query {
+                crafts {
+                    rewardItems {
+                        item {
+                            name
+                        }
+                    }
+                    requiredItems {
+                        item {
+                            name
+                        }
+                    }
+                }
+            }`
+        });
+
+        caches.craft.nameCache = [];
+        craftResponse.data.crafts.map(craft => {
+            caches.craft.nameCache = [...new Set([...caches.craft.nameCache, ...[...new Set([...craft.rewardItems.map(item => item.item.name), ...craft.requiredItems.map(item => item.item.name)])]])];
+            return;
+        });
+        caches.craft.nameCache.sort();
     } catch (requestError) {
         console.error(requestError);
     }
@@ -35,6 +104,12 @@ function autocomplete(interaction) {
         console.error(getError);
     }
 
+    let lookupCache = caches.default.lookupCache;
+    let nameCache = caches.default.nameCache;
+    if (caches[interaction.commandName]) {
+        lookupCache = caches[interaction.commandName].lookupCache;
+        nameCache = caches[interaction.commandName].nameCache;
+    }
     if (lookupCache[searchString]) {
         return [...lookupCache[searchString]];
     }

--- a/modules/get-crafts-barters.mjs
+++ b/modules/get-crafts-barters.mjs
@@ -2,7 +2,7 @@ import ttRequest from "./tt-request.mjs";
 
 const getCraftsBarters = async () => {
     const query = `query {
-        crafts { source duration requiredItems { item { id name avg24hPrice lastLowPrice buyFor { source price currency requirements { type value } } } count } rewardItems { item { id name iconLink link } count } }
+        crafts { source duration requiredItems { item { id name iconLink avg24hPrice lastLowPrice buyFor { source price currency requirements { type value } } } count attributes { type value } } rewardItems { item { id name iconLink link } count } }
         barters { source requiredItems { item { id name avg24hPrice lastLowPrice buyFor { source price currency requirements { type value } } } count } rewardItems { item { id name iconLink link } count } }
     }`;
     const response = await ttRequest({ graphql: query });


### PR DESCRIPTION
Also enhances /craft and /barter autocomplete to only show suggest items that are used in crafts and barters.