### PR TITLE
Show craft/barter totals on new line

### DIFF
--- a/commands/barter.mjs
+++ b/commands/barter.mjs
@@ -110,7 +110,7 @@ const defaultFunction = {
                 embed.addField(req.item.name, itemCost.toLocaleString() + "₽ x " + req.count, true);
             }
 
-            embed.addField("Total", totalCost.toLocaleString() + "₽", true);
+            embed.addField("Total", totalCost.toLocaleString() + "₽", false);
 
             embeds.push(embed);
 

--- a/commands/craft.mjs
+++ b/commands/craft.mjs
@@ -132,11 +132,11 @@ const defaultFunction = {
                 //totalCost += req.item.avg24hPrice * req.count;
                 embed.addField(req.item.name, itemCost.toLocaleString() + "₽ x " + req.count, true);
             }
-            embed.addField("Total", totalCost.toLocaleString() + "₽", true);
+            embed.addField("Total", totalCost.toLocaleString() + "₽", false);
 
             embeds.push(embed);
             if (toolsEmbed.fields.length > 0) {
-                toolsEmbed.addField("Total", toolCost.toLocaleString() + "₽", true);
+                toolsEmbed.addField("Total", toolCost.toLocaleString() + "₽", false);
                 embeds.push(toolsEmbed);
             }
 


### PR DESCRIPTION
The "Total" fields for crafts and barters is now not displayed inline. This means the total shows on its own line, which makes it easier to read at a glance.