### PR TITLE
use sell value of items for barter cost

### DIFF
--- a/commands/barter.mjs
+++ b/commands/barter.mjs
@@ -100,8 +100,30 @@ const defaultFunction = {
                     }
                 }
 
+                let bestSellPrice = 0;
+                for (const offer of req.item.sellFor) {
+                    if (!offer.vendor.trader) {
+                        continue;
+                    }
+                    if (offer.priceRUB > bestSellPrice) {
+                        bestSellPrice = offer.priceRUB;
+                    }
+                }
+
+                let reqName = req.item.name;
+                if (itemCost === 0) {
+                    itemCost = bestSellPrice;
+
+                    const isDogTag = req.attributes.some(att => att.name === 'minLevel');
+                    if (isDogTag) {
+                        const tagLevel = req.attributes.find(att => att.name === 'minLevel').value;
+                        itemCost = bestSellPrice * tagLevel;
+                        reqName += ' >= '+tagLevel;
+                    }
+                }
+
                 totalCost += itemCost * req.count;
-                embed.addField(req.item.name, itemCost.toLocaleString() + "₽ x " + req.count, true);
+                embed.addField(reqName, itemCost.toLocaleString() + "₽ x " + req.count, true);
             }
 
             embed.addField("Total", totalCost.toLocaleString() + "₽", false);

--- a/commands/barter.mjs
+++ b/commands/barter.mjs
@@ -4,7 +4,7 @@ import { MessageEmbed } from 'discord.js';
 import getCraftsBarters from '../modules/get-crafts-barters.mjs';
 import progress from '../modules/progress.mjs';
 
-const MAX_BARTERS = 2;
+const MAX_BARTERS = 3;
 
 const defaultFunction = {
     data: new SlashCommandBuilder()

--- a/commands/price.mjs
+++ b/commands/price.mjs
@@ -208,6 +208,26 @@ const defaultFunction = {
                             }
                         }
 
+                        let bestSellPrice = 0;
+                        for (const offer of req.item.sellFor) {
+                            if (!offer.vendor.trader) {
+                                continue;
+                            }
+                            if (offer.priceRUB > bestSellPrice) {
+                                bestSellPrice = offer.priceRUB;
+                            }
+                        }
+
+                        if (itemCost === 0) {
+                            itemCost = bestSellPrice;
+        
+                            const isDogTag = req.attributes.some(att => att.name === 'minLevel');
+                            if (isDogTag) {
+                                const tagLevel = req.attributes.find(att => att.name === 'minLevel').value;
+                                itemCost = bestSellPrice * tagLevel;
+                            }
+                        }
+
                         barterCost += itemCost * req.count;
                     }
 

--- a/modules/get-crafts-barters.mjs
+++ b/modules/get-crafts-barters.mjs
@@ -13,6 +13,7 @@ const getCraftsBarters = async () => {
             item {
               id
               name
+              basePrice
               iconLink
               avg24hPrice
               lastLowPrice
@@ -68,6 +69,7 @@ const getCraftsBarters = async () => {
             item {
               id
               name
+              basePrice
               avg24hPrice
               lastLowPrice
               link
@@ -92,6 +94,23 @@ const getCraftsBarters = async () => {
                   value
                 }
               }
+              sellFor {
+                price
+                currency
+                priceRUB
+                vendor {
+                  name
+                  ...on TraderOffer {
+                    trader {
+                      id
+                    }
+                  }
+                }
+              }
+            }
+            attributes {
+              name
+              value
             }
             count
           }


### PR DESCRIPTION
Currently, barter item requirements that don't have any available price (e.g., dog tags), show a cost of zero. Now such items will show a cost equal to the highest sell-to-trader value you can get for the item. Dog tags additionally use the correct value for their level.