### PR TITLE
Update autocomplete cache

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -21,7 +21,7 @@ if (process.env.NODE_ENV === 'production') {
         tracesSampleRate: 1.0,
     });
 } else {
-    console.log('Bypassing Sentry in dev environment');
+    console.log(`Bypassing Sentry in ${process.env.NODE_ENV || 'dev'} environment`);
 }
 
 // if(process.env.NODE_ENV === 'production'){

--- a/modules/autocomplete.mjs
+++ b/modules/autocomplete.mjs
@@ -64,21 +64,22 @@ async function fillCache() {
             return item.name;
         }).sort();
 
-        let barterNameCache = [];
+        let barterNameSet = new Set();
         itemNamesResponse.data.items.filter(item => {
             return item.bartersFor.length > 0 || item.bartersUsing.length > 0;
         }).forEach(item => {
-            barterNameCache = [...new Set([...barterNameCache, item.name])];
+            barterNameSet.add(item.name);
         });
-        caches.barter.nameCache = barterNameCache.sort();
+        caches.barter.nameCache = [...barterNameSet].sort();
 
-        let craftNameCache = [];
+        let craftNameSet = new Set();
         itemNamesResponse.data.items.filter(item => {
             return item.craftsFor.length > 0 || item.craftsUsing.length > 0;
         }).forEach(item => {
-            craftNameCache = [...new Set([...craftNameCache, item.name])];
+
+            craftNameSet.add(item.name);
         });
-        caches.craft.nameCache = craftNameCache.sort();
+        caches.craft.nameCache = [...craftNameSet].sort();
     } catch (requestError) {
         console.error(requestError);
     }

--- a/modules/autocomplete.mjs
+++ b/modules/autocomplete.mjs
@@ -76,7 +76,6 @@ async function fillCache() {
         itemNamesResponse.data.items.filter(item => {
             return item.craftsFor.length > 0 || item.craftsUsing.length > 0;
         }).forEach(item => {
-
             craftNameSet.add(item.name);
         });
         caches.craft.nameCache = [...craftNameSet].sort();

--- a/modules/autocomplete.mjs
+++ b/modules/autocomplete.mjs
@@ -56,23 +56,20 @@ async function fillCache() {
             return item.category.id === '5485a8684bdc2da71d8b4567';
         }).map(item => {
             return item.name;
-        });
-        caches.ammo.nameCache.sort();
+        }).sort();
 
         caches.stim.nameCache = itemNamesResponse.data.items.filter(item => {
             return item.category.id === '5448f3a64bdc2d60728b456a';
         }).map(item => {
             return item.name;
-        });
-        caches.stim.nameCache.sort();
+        }).sort();
 
         let barterNameCache = [];
         itemNamesResponse.data.items.filter(item => {
             return item.bartersFor.length > 0 || item.bartersUsing.length > 0;
         }).forEach(item => {
             barterNameCache = [...new Set([...barterNameCache, item.name])];
-        });
-        barterNameCache.sort();
+        }).sort();
         caches.barter.nameCache = barterNameCache;
 
         let craftNameCache = [];
@@ -81,8 +78,7 @@ async function fillCache() {
         }).forEach(item => {
             craftNameCache = [...new Set([...craftNameCache, item.name])];
             return;
-        });
-        craftNameCache.sort();
+        }).sort();
         caches.craft.nameCache = craftNameCache;
     } catch (requestError) {
         console.error(requestError);

--- a/modules/autocomplete.mjs
+++ b/modules/autocomplete.mjs
@@ -24,18 +24,6 @@ const caches = {
 }
 
 async function fillCache() {
-    let cacheFilled = true;
-    for (const cacheName in caches) {
-        if (!caches[cacheName].nameCache) {
-            cacheFilled = false;
-            break;
-        }
-    }
-    if (cacheFilled) {
-        return true;
-    }
-
-    console.log('Filling autocomplete cache');
     console.time('Fill-autocomplete-cache');
     try {
         const itemNamesResponse = await graphqlRequest({
@@ -78,22 +66,24 @@ async function fillCache() {
         });
         caches.stim.nameCache.sort();
 
-        caches.barter.nameCache = [];
+        let barterNameCache = [];
         itemNamesResponse.data.items.filter(item => {
             return item.bartersFor.length > 0 || item.bartersUsing.length > 0;
         }).forEach(item => {
-            caches.barter.nameCache = [...new Set([...caches.barter.nameCache, item.name])];
+            barterNameCache = [...new Set([...barterNameCache, item.name])];
         });
-        caches.barter.nameCache.sort();
+        barterNameCache.sort();
+        caches.barter.nameCache = barterNameCache;
 
-        caches.craft.nameCache = [];
+        let craftNameCache = [];
         itemNamesResponse.data.items.filter(item => {
             return item.craftsFor.length > 0 || item.craftsUsing.length > 0;
         }).forEach(item => {
-            caches.craft.nameCache = [...new Set([...caches.craft.nameCache, item.name])];
+            craftNameCache = [...new Set([...craftNameCache, item.name])];
             return;
         });
-        caches.craft.nameCache.sort();
+        craftNameCache.sort();
+        caches.craft.nameCache = craftNameCache;
     } catch (requestError) {
         console.error(requestError);
     }
@@ -130,9 +120,10 @@ function autocomplete(interaction) {
 
 let updateInterval = false;
 if (process.env.NODE_ENV !== 'ci') {
-    updateInterval = setInterval(fillCache, 1000 * 60 * 10);
+    console.log('setting interval');
+    updateInterval = setInterval(() => fillCache(), 1000 * 60 * 10);
     updateInterval.unref();
-}
+} 
 
 export {
     fillCache,

--- a/modules/autocomplete.mjs
+++ b/modules/autocomplete.mjs
@@ -115,7 +115,7 @@ function autocomplete(interaction) {
 
 let updateInterval = false;
 if (process.env.NODE_ENV !== 'ci') {
-    updateInterval = setInterval(() => fillCache(), 1000 * 60 * 10);
+    updateInterval = setInterval(fillCache, 1000 * 60 * 10);
     updateInterval.unref();
 } 
 

--- a/modules/autocomplete.mjs
+++ b/modules/autocomplete.mjs
@@ -115,7 +115,6 @@ function autocomplete(interaction) {
 
 let updateInterval = false;
 if (process.env.NODE_ENV !== 'ci') {
-    console.log('setting interval');
     updateInterval = setInterval(() => fillCache(), 1000 * 60 * 10);
     updateInterval.unref();
 } 

--- a/modules/autocomplete.mjs
+++ b/modules/autocomplete.mjs
@@ -69,7 +69,8 @@ async function fillCache() {
             return item.bartersFor.length > 0 || item.bartersUsing.length > 0;
         }).forEach(item => {
             barterNameCache = [...new Set([...barterNameCache, item.name])];
-        }).sort();
+        });
+        barterNameCache.sort();
         caches.barter.nameCache = barterNameCache;
 
         let craftNameCache = [];
@@ -78,7 +79,8 @@ async function fillCache() {
         }).forEach(item => {
             craftNameCache = [...new Set([...craftNameCache, item.name])];
             return;
-        }).sort();
+        });
+        craftNameCache.sort();
         caches.craft.nameCache = craftNameCache;
     } catch (requestError) {
         console.error(requestError);

--- a/modules/autocomplete.mjs
+++ b/modules/autocomplete.mjs
@@ -70,8 +70,7 @@ async function fillCache() {
         }).forEach(item => {
             barterNameCache = [...new Set([...barterNameCache, item.name])];
         });
-        barterNameCache.sort();
-        caches.barter.nameCache = barterNameCache;
+        caches.barter.nameCache = barterNameCache.sort();
 
         let craftNameCache = [];
         itemNamesResponse.data.items.filter(item => {
@@ -80,8 +79,7 @@ async function fillCache() {
             craftNameCache = [...new Set([...craftNameCache, item.name])];
             return;
         });
-        craftNameCache.sort();
-        caches.craft.nameCache = craftNameCache;
+        caches.craft.nameCache = craftNameCache.sort();
     } catch (requestError) {
         console.error(requestError);
     }

--- a/modules/autocomplete.mjs
+++ b/modules/autocomplete.mjs
@@ -77,7 +77,6 @@ async function fillCache() {
             return item.craftsFor.length > 0 || item.craftsUsing.length > 0;
         }).forEach(item => {
             craftNameCache = [...new Set([...craftNameCache, item.name])];
-            return;
         });
         caches.craft.nameCache = craftNameCache.sort();
     } catch (requestError) {


### PR DESCRIPTION
Previously, the command autocomplete cache filled when the bot was started and then did not update while the bot was running. So if item names changes or were added, the bot wouldn't be aware of them. This changes it to update the autocomplete cache every 10 minutes.

It also reduces the API requests from three to one and filling the cache takes much less time.