### PR TITLE
Clear lookup cache on update

### DIFF
--- a/modules/autocomplete.mjs
+++ b/modules/autocomplete.mjs
@@ -52,7 +52,7 @@ async function fillCache() {
             }`
         });
 
-        caches.default.nameCache = itemNamesResponse.data.items.map(item => item.name);
+        caches.default.nameCache = itemNamesResponse.data.items.map(item => item.name).sort();
         caches.default.lookupCache = {};
 
         caches.ammo.nameCache = itemNamesResponse.data.items.filter(item => {

--- a/modules/autocomplete.mjs
+++ b/modules/autocomplete.mjs
@@ -23,6 +23,8 @@ const caches = {
     }
 }
 
+const updateIntervalMinutes = 10;
+
 async function fillCache() {
     console.time('Fill-autocomplete-cache');
     try {
@@ -51,18 +53,21 @@ async function fillCache() {
         });
 
         caches.default.nameCache = itemNamesResponse.data.items.map(item => item.name);
+        caches.default.lookupCache = {};
 
         caches.ammo.nameCache = itemNamesResponse.data.items.filter(item => {
             return item.category.id === '5485a8684bdc2da71d8b4567';
         }).map(item => {
             return item.name;
         }).sort();
+        caches.ammo.lookupCache = {};
 
         caches.stim.nameCache = itemNamesResponse.data.items.filter(item => {
             return item.category.id === '5448f3a64bdc2d60728b456a';
         }).map(item => {
             return item.name;
         }).sort();
+        caches.stim.lookupCache = {};
 
         let barterNameSet = new Set();
         itemNamesResponse.data.items.filter(item => {
@@ -71,6 +76,7 @@ async function fillCache() {
             barterNameSet.add(item.name);
         });
         caches.barter.nameCache = [...barterNameSet].sort();
+        caches.barter.lookupCache = {};
 
         let craftNameSet = new Set();
         itemNamesResponse.data.items.filter(item => {
@@ -79,6 +85,7 @@ async function fillCache() {
             craftNameSet.add(item.name);
         });
         caches.craft.nameCache = [...craftNameSet].sort();
+        caches.craft.lookupCache = {};
     } catch (requestError) {
         console.error(requestError);
     }
@@ -113,10 +120,8 @@ function autocomplete(interaction) {
     return [...lookupCache[searchString]];
 };
 
-let updateInterval = false;
 if (process.env.NODE_ENV !== 'ci') {
-    updateInterval = setInterval(fillCache, 1000 * 60 * 10);
-    updateInterval.unref();
+    setInterval(fillCache, 1000 * 60 * updateIntervalMinutes).unref();
 } 
 
 export {

--- a/modules/game-data.mjs
+++ b/modules/game-data.mjs
@@ -27,6 +27,8 @@ let mapChoices = [];
 let traderChoices = [];
 let hideoutChoices = [];
 
+const updateIntervalMinutes = 10;
+
 export async function updateMaps() {
     const query = `query {
         maps {
@@ -175,11 +177,8 @@ const updateAll = async () => {
     ]);
 };
 
-let updateInterval = false;
-
 if (process.env.NODE_ENV !== 'ci') {
-    updateInterval = setInterval(updateAll, 1000 * 60 * 10);
-    updateInterval.unref();
+    setInterval(updateAll, 1000 * 60 * updateIntervalMinutes).unref();
 }
 
 export default {

--- a/modules/loot-tier.js
+++ b/modules/loot-tier.js
@@ -7,7 +7,7 @@ const tiers = {
     average: 11000
 };
 
-let intervalId = false;
+const updateIntervalMinutes = 60;
 
 const arrayAverage = (array) => array.reduce((a, b) => a + b) / array.length;
 
@@ -89,8 +89,7 @@ const updateTiers = async () => {
 };
 
 if (process.env.NODE_ENV !== 'ci') {
-    intervalId = setInterval(updateTiers, 1000 * 60 * 60);
-    intervalId.unref();
+    setInterval(updateTiers, 1000 * 60 * updateIntervalMinutes).unref();
     updateTiers();
 }
 
@@ -120,13 +119,8 @@ const getTiers = () => {
     return tiers;
 };
 
-const cancelTierUpdate = () => {
-    clearInterval(intervalId);
-};
-
 export {
-    getTiers,
-    cancelTierUpdate,
+    getTiers
 };
 
 export default get_item_tier;

--- a/modules/progress.mjs
+++ b/modules/progress.mjs
@@ -17,6 +17,8 @@ const defaultProgress = {
     skills: {}
 };
 
+const tarkovTrackerUpdateIntervalMinutes = 1;
+
 const buildDefaultProgress = id => {
     const progress = {
         id: id,
@@ -86,7 +88,7 @@ const updateTarkovTracker = async () => {
         }
     }
     saveUserProgress();
-    setTimeout(updateTarkovTracker, 1000 * 60).unref();
+    setTimeout(updateTarkovTracker, 1000 * 60 * tarkovTrackerUpdateIntervalMinutes).unref();
 };
 
 const saveUserProgress = () => {
@@ -216,7 +218,7 @@ if (process.env.NODE_ENV !== 'ci') {
             }
         }*/
     }
-    setTimeout(updateTarkovTracker, 1000 * 60).unref();
+    setTimeout(updateTarkovTracker, 1000 * 60 * tarkovTrackerUpdateIntervalMinutes).unref();
 }
 
 export default {

--- a/modules/progress.mjs
+++ b/modules/progress.mjs
@@ -50,8 +50,6 @@ const getUsersForUpdate = () => {
     });
 };
 
-let tarkovTrackerTimeout = false;
-
 const updateTarkovTracker = async () => {
     const users = getUsersForUpdate();
     const hideout = await gameData.hideout.getAll();
@@ -88,8 +86,7 @@ const updateTarkovTracker = async () => {
         }
     }
     saveUserProgress();
-    tarkovTrackerTimeout = setTimeout(updateTarkovTracker, 1000 * 60);
-    tarkovTrackerTimeout.unref();
+    setTimeout(updateTarkovTracker, 1000 * 60).unref();
 };
 
 const saveUserProgress = () => {
@@ -219,8 +216,7 @@ if (process.env.NODE_ENV !== 'ci') {
             }
         }*/
     }
-    tarkovTrackerTimeout = setTimeout(updateTarkovTracker, 1000 * 60);
-    tarkovTrackerTimeout.unref();
+    setTimeout(updateTarkovTracker, 1000 * 60).unref();
 }
 
 export default {


### PR DESCRIPTION
The bot caches which items return for the autocomplete for a given search string. However, this lookup cache was not clearing when the name cache updated every 10 minutes. That could result in a previously-cached search not returning a new item that had been added. This change clears the lookup cache when the name cache is refreshed every 10 minutes.