### PR TITLE
move no-flea to bottom

### DIFF
--- a/commands/tier.mjs
+++ b/commands/tier.mjs
@@ -15,10 +15,10 @@ const defaultFunction = {
             .setDescription(`
                 Loot tiers are divided primarily by the per-slot value of the item:
                 • ${lootTier(tiers.legendary).msg} >= ${tiers.legendary.toLocaleString()}₽
-                • ${lootTier(0, true).msg}
                 • ${lootTier(tiers.great).msg} >= ${tiers.great.toLocaleString()}₽
                 • ${lootTier(tiers.average).msg} >= ${tiers.average.toLocaleString()}₽
                 • ${lootTier(tiers.average -1).msg} < ${tiers.average.toLocaleString()}₽
+                • ${lootTier(0, true).msg}
             `);
 
         await interaction.reply({ embeds: [embed] });


### PR DESCRIPTION
This pull request moves the `no-flea` loot tier to the bottom of the message to make it more readable by humans