### PR TITLE
disable admin notification

### DIFF
--- a/index.mjs
+++ b/index.mjs
@@ -62,13 +62,13 @@ discordClient.on('ready', () => {
 
     console.log(message);
 
-    // Send a DM to the admins that the bot is online
-    // if (process.env.ADMIN_ID) {
-    //     discordClient.users.fetch(process.env.ADMIN_ID.split(',')[0], false)
-    //         .then(user => {
-    //             user.send(message);
-    //         });
-    // }
+    // Send a DM to the admin that the bot is online for testing
+    if (process.env.ADMIN_ID && process.env.NODE_ENV !== 'production') {
+        discordClient.users.fetch(process.env.ADMIN_ID.split(',')[0], false)
+            .then(user => {
+                user.send(message);
+            });
+    }
 
     discordClient.user.setActivity('Tarkov.dev', {
         type: 'PLAYING',

--- a/index.mjs
+++ b/index.mjs
@@ -62,12 +62,13 @@ discordClient.on('ready', () => {
 
     console.log(message);
 
-    if (process.env.ADMIN_ID) {
-        discordClient.users.fetch(process.env.ADMIN_ID.split(',')[0], false)
-            .then(user => {
-                user.send(message);
-            });
-    }
+    // Send a DM to the admins that the bot is online
+    // if (process.env.ADMIN_ID) {
+    //     discordClient.users.fetch(process.env.ADMIN_ID.split(',')[0], false)
+    //         .then(user => {
+    //             user.send(message);
+    //         });
+    // }
 
     discordClient.user.setActivity('Tarkov.dev', {
         type: 'PLAYING',

--- a/index.mjs
+++ b/index.mjs
@@ -63,12 +63,12 @@ discordClient.on('ready', () => {
     console.log(message);
 
     // Send a DM to the admin that the bot is online for testing
-    if (process.env.ADMIN_ID && process.env.NODE_ENV !== 'production') {
-        discordClient.users.fetch(process.env.ADMIN_ID.split(',')[0], false)
-            .then(user => {
-                user.send(message);
-            });
-    }
+    // if (process.env.ADMIN_ID && process.env.NODE_ENV !== 'production') {
+    //     discordClient.users.fetch(process.env.ADMIN_ID.split(',')[0], false)
+    //         .then(user => {
+    //             user.send(message);
+    //         });
+    // }
 
     discordClient.user.setActivity('Tarkov.dev', {
         type: 'PLAYING',


### PR DESCRIPTION
# disable admin notification

This pull request disables the notification that admins get every single time the bot comes online. This was needed during early development of the bot but not so much anymore as we have good monitoring via our status page and via new relic.

I am just commenting this out for now, should we need it in the future