### PR TITLE
export env var to disable new-relic in development

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "node index.mjs",
-    "dev": "cross-env NODE_ENV=development nodemon --ignore cache/ -r dotenv/config index.mjs",
+    "dev": "cross-env NODE_ENV=development NEW_RELIC_ENABLED=false nodemon --ignore cache/ -r dotenv/config index.mjs",
     "dev-commands": "cross-env NODE_ENV=ci node deploy-commands-dev.mjs"
   },
   "type": "module",


### PR DESCRIPTION
This pull request disables new relic in development when the `npm run dev` command is executed.