### PR TITLE
webhook alert on changed choices

### DIFF
--- a/modules/webhook.mjs
+++ b/modules/webhook.mjs
@@ -1,0 +1,49 @@
+import { WebhookClient, EmbedBuilder } from 'discord.js';
+
+let webhookClient = false;
+
+if (process.env.WEBHOOK_URL) {
+    const options = {
+        url: process.env.WEBHOOK_URL
+    };
+    webhookClient = new WebhookClient(options);
+    webhookClient.name = 'Stash';
+}
+
+export default async function sendWebhook(message) {
+    if (!webhookClient) {
+        return;
+    }
+    if (typeof message === 'string') {
+        message = {
+            title: message
+        };
+    }
+    const embed = new EmbedBuilder();
+    if (message.title) {
+        if (message.title.length > 256) {
+            if (!message.message) {
+                message.message = message.title;
+            }
+            message.title = message.title.substring(0, 256);
+        }
+        embed.setTitle(message.title);
+    }
+    if (message.message) {
+        if (typeof message.message !== 'string') {
+            if (typeof message.message !== 'object') {
+                message.message = message.message.toString();
+            } else {
+                if (message.stack) {
+                    message.message = message.stack;
+                } else {
+                    message.message = '`'+JSON.stringify(message.message, null, 4)+'`';
+                }
+            }
+        }
+        embed.setDescription(message.message);
+    }
+    return webhookClient.send({
+        embeds: [embed]
+    });
+};


### PR DESCRIPTION
Some commands have a limited set of choices that are generated from API data when the bot is first deployed. Most of the time, this causes no issues. But if a new option is added or removed after deployment, the choices can become out of date. For example, if a boss is added (e.g., the "gifter" for the holiday events), that new boss will be missing from the /boss command choices. This PR makes the bot send an alert using WEBHOOK_URL if it detects choices have become out of date. That's our signal to re-deploy the bot to refresh the command option choices.