### PR TITLE
Split shard messenger to new module

### DIFF
--- a/bot.mjs
+++ b/bot.mjs
@@ -8,7 +8,7 @@ import {
 } from 'discord.js';
 
 import autocomplete from './modules/autocomplete.mjs';
-import { updateAll } from './modules/game-data.mjs';
+//import { updateChoices } from './modules/game-data.mjs';
 import { initShardMessenger, respondToParentMessage } from './modules/shard-messenger.mjs';
 
 if (process.env.NODE_ENV === 'production') {
@@ -43,9 +43,9 @@ for (const file of commandFiles) {
     discordClient.commands.set(command.default.data.name, command);
 }
 
-console.time('Prefetch-game-data');
-await updateAll();
-console.timeEnd('Prefetch-game-data');
+//console.time('Prefetch-choice-data');
+//await updateChoices();
+//console.timeEnd('Prefetch-choice-data');
 
 discordClient.on('ready', () => {
     console.log(`Logged in as ${discordClient.user.tag} on shard ${discordClient.shard.ids[0]}`);

--- a/commands/boss.mjs
+++ b/commands/boss.mjs
@@ -73,7 +73,7 @@ const defaultFunction = {
         // Fetch all items
         const items = await gameData.items.getAll(interaction.locale);
 
-        const tiers = getTiers();
+        const tiers = await getTiers();
 
         // Construct the embed
         const embed = new EmbedBuilder();

--- a/commands/boss.mjs
+++ b/commands/boss.mjs
@@ -134,6 +134,7 @@ const defaultFunction = {
         }
         loot = loot.map(item => item.name).join(', ');
         embed.setThumbnail(boss.imagePortraitLink);
+        embed.setURL(`https://tarkov.dev/boss/${boss.normalizedName}`);
 
         for (const bossData of bossDetails) {
             if (bossData.name === bossName) {

--- a/commands/price.mjs
+++ b/commands/price.mjs
@@ -160,7 +160,7 @@ const defaultFunction = {
             body += `• ${t('Sell to')}: \`${sellTo}\` ${t('for')} \`${tierPrice.toLocaleString(interaction.locale) + "₽"}\`\n`;
 
             // Calculate item tier
-            let tier = lootTier(tierPrice / (item.width * item.height), item.types.includes('noFlea'));
+            let tier = await lootTier(tierPrice / (item.width * item.height), item.types.includes('noFlea'));
             embed.setColor(tier.color);
             body += `• ${t('Item Tier')}: ${t(tier.msg)}\n`;
 

--- a/commands/tier.mjs
+++ b/commands/tier.mjs
@@ -1,6 +1,6 @@
 import { EmbedBuilder, SlashCommandBuilder } from 'discord.js';
 
-import lootTier, { getTiers } from '../modules/loot-tier.mjs';
+import getPriceTier, { getTiers } from '../modules/loot-tier.mjs';
 import { getFixedT, getCommandLocalizations } from '../modules/translations.mjs';
 
 const defaultFunction = {
@@ -12,16 +12,16 @@ const defaultFunction = {
 
     async execute(interaction) {
         const t = getFixedT(interaction.locale);
-        const tiers = getTiers();
+        const tiers = await getTiers();
         const embed = new EmbedBuilder()
             .setTitle(t('Loot Tiers'))
             .setDescription(`
                 ${t('Loot tiers are divided primarily by the per-slot value of the item')}:
-                • ${t(lootTier(tiers.legendary).msg)} ≥ ${tiers.legendary.toLocaleString(interaction.locale)}₽
-                • ${t(lootTier(0, true).msg)}
-                • ${t(lootTier(tiers.great).msg)} ≥ ${tiers.great.toLocaleString(interaction.locale)}₽
-                • ${t(lootTier(tiers.average).msg)} ≥ ${tiers.average.toLocaleString(interaction.locale)}₽
-                • ${t(lootTier(tiers.average -1).msg)} < ${tiers.average.toLocaleString(interaction.locale)}₽
+                • ${t((await getPriceTier(tiers.legendary)).msg)} ≥ ${tiers.legendary.toLocaleString(interaction.locale)}₽
+                • ${t((await getPriceTier(0, true)).msg)}
+                • ${t((await getPriceTier(tiers.great)).msg)} ≥ ${tiers.great.toLocaleString(interaction.locale)}₽
+                • ${t((await getPriceTier(tiers.average)).msg)} ≥ ${tiers.average.toLocaleString(interaction.locale)}₽
+                • ${t((await getPriceTier(tiers.average -1)).msg)} < ${tiers.average.toLocaleString(interaction.locale)}₽
             `);
 
         return interaction.reply({ embeds: [embed] });

--- a/index.mjs
+++ b/index.mjs
@@ -61,7 +61,9 @@ if (process.env.NODE_ENV === 'production') {
     console.log("Healthcheck disabled");
 }
 
+console.time('Prefetch-game-data');
 gameData.updateAll().then(() => {
+    console.timeEnd('Prefetch-game-data');
     const choiceTypes = [
         'traders',
         'maps',

--- a/index.mjs
+++ b/index.mjs
@@ -6,6 +6,7 @@ import { ShardingManager } from 'discord.js';
 
 import progress from './modules/progress.mjs';
 import gameData from './modules/game-data.mjs';
+import { initShardMessenger, respondToShardMessage } from './modules/shard-messenger.mjs';
 
 const manager = new ShardingManager('./bot.mjs', { token: process.env.DISCORD_API_TOKEN });
 let healthcheckJob = false;
@@ -16,72 +17,14 @@ const startingChoices = {};
 manager.on('shardCreate', shard => {
     console.log(`Created shard ${shard.id}`);
     shard.on('message', async message => {
-        //console.log(`ShardingManager received message from shard ${shard.id}`, message);
-        if (message.type === 'getReply') {
-            const response = {uuid: message.uuid};
-            try {
-                if (message.data === 'userProgress') {
-                    response.data = await progress.getProgress(message.userId);
-                }
-                if (message.data === 'defaultUserProgress') {
-                    response.data = await progress.getDefaultProgress();
-                }
-                if (message.data === 'safeUserProgress') {
-                    response.data = await progress.getSafeProgress(message.userId);
-                }
-                if (message.data === 'userTarkovTrackerUpdateTime') {
-                    response.data = await progress.getUpdateTime(message.userId);
-                }
-                if (message.data === 'setUserLevel') {
-                    await progress.setLevel(message.userId, message.level);
-                    response.data = message.level;
-                }
-                if (message.data === 'setUserTraderLevel') {
-                    await progress.setTrader(message.userId, message.traderId, message.level);
-                    response.data = message.level;
-                }
-                if (message.data === 'setUserHideoutLevel') {
-                    await progress.setHideout(message.userId, message.stationId, message.level);
-                    response.data = message.level;
-                }
-                if (message.data === 'setUserSkillLevel') {
-                    await progress.setSkill(message.userId, message.skillId, message.level);
-                    response.data = message.level;
-                }
-                if (message.data === 'userTraderRestockAlerts') {
-                    response.data = await progress.getRestockAlerts(message.userId);
-                }
-                if (message.data === 'addUserTraderRestockAlert') {
-                    response.data = await progress.addRestockAlert(message.userId, message.traders, message.locale);
-                }
-                if (message.data === 'removeUserTraderRestockAlert') {
-                    response.data = await progress.removeRestockAlert(message.userId, message.traders, message.locale);
-                }
-                if (message.data === 'setUserTarkovTrackerToken') {
-                    await progress.setToken(message.userId, message.token);
-                    response.data = message.token;
-                }
-                if (message.data === 'guildTraderRestockAlertChannel') {
-                    response.data = await progress.setGuildTraderRestockAlertChannel(message.guildId, message.channelId, message.locale);
-                }
-            } catch (error) {
-                response.data = null;
-                response.error = {message: error.message, stack: error.stack};
-            }
-            return shard.send(response);
-        }
-        if (message.type === 'reportIssue') {
-            manager.broadcast(message);
-        }
-        if (message.uuid) {
-            shard.emit(message.uuid, message);
-        }
+        return respondToShardMessage(message, shard);
     });
 });
 
 manager.spawn().then(shards => {
     console.log(`🟢 Systems now online with ${shards.size} shards`);
-    progress.init(manager);
+    initShardMessenger(manager);
+    progress.init();
     const shutdown = () => {
         if (shutdownSignalReceived) return;
         shutdownSignalReceived = true;

--- a/modules/game-data.mjs
+++ b/modules/game-data.mjs
@@ -56,7 +56,7 @@ let bossChoices = [];
 let traderChoices = [];
 let hideoutChoices = [];
 
-const updateIntervalMinutes = 10;
+const updateIntervalMinutes = 5;
 
 const eventEmitter = new EventEmitter();
 

--- a/modules/game-data.mjs
+++ b/modules/game-data.mjs
@@ -841,7 +841,7 @@ export async function updateAll(rejectOnError = false) {
     ]);
 }*/
 
-if (process.env.NODE_ENV !== 'ci') {
+if (process.env.NODE_ENV !== 'ci' && !process.env.IS_SHARD) {
     setInterval(updateAll, 1000 * 60 * updateIntervalMinutes).unref();
 }
 

--- a/modules/graphql-request.mjs
+++ b/modules/graphql-request.mjs
@@ -12,7 +12,7 @@ const graphqlRequest = async (options) => {
         body: JSON.stringify({
             query: options.graphql,
         }),
-        headers: { "user-agent": "stash-tarkov-dev", "Content-Type": 'application/json' },
+        headers: { "user-agent": "stash-tarkov-dev", "Content-Type": 'application/json', 'Referer': 'http://stash.tarkov.dev' },
         resolveBodyOnly: true,
     });
 };

--- a/modules/loot-tier.mjs
+++ b/modules/loot-tier.mjs
@@ -1,4 +1,5 @@
 import colors from './colors.js';
+import { getParentReply } from './shard-messenger.mjs';
 
 const tiers = {
     legendary: 40000,
@@ -43,7 +44,10 @@ export async function updateTiers(items) {
     tiers.average = averageFloor;
 }
 
-function get_item_tier(price, noFlea) {
+function getPriceTier(price, noFlea) {
+    if (process.env.IS_SHARD) {
+        return getParentReply({data: 'getPriceTier', price, noFlea})
+    }
     let color, tier_msg;
     if (price >= tiers.legendary) {
         color = colors.yellow;
@@ -61,12 +65,14 @@ function get_item_tier(price, noFlea) {
         color = colors.red;
         tier_msg = "🔴 Poor";
     }
-
     return { color: color, msg: tier_msg };
 }
 
 export function getTiers() {
+    if (process.env.IS_SHARD) {
+        return getParentReply({data: 'getTiers'})
+    }
     return tiers;
 }
 
-export default get_item_tier;
+export default getPriceTier;

--- a/modules/progress-shard.mjs
+++ b/modules/progress-shard.mjs
@@ -1,8 +1,5 @@
-import { v4 as uuidv4 } from "uuid";
-
 import gameData from "./game-data.mjs";
-
-let discordClient;
+import { getParentReply } from "./shard-messenger.mjs";
 
 const getFleaFactors = prog => {
     if (!prog) {
@@ -71,18 +68,6 @@ const optimalFleaPrice = async (progress, baseValue, lowerBound, upperBound) => 
     return highPrice;
 };
 
-const getParentReply = async(message) => {
-    message.uuid = uuidv4();
-    message.type = 'getReply';
-    return new Promise((resolve, reject) => {
-        process.once(message.uuid, response => {
-            if (response.error) return reject(response.error);
-            resolve(response.data);
-        });
-        discordClient.shard.send(message);
-    });
-};
-
 const getProgress = async (id) => {
     return getParentReply({data: 'userProgress', userId: id});
 };
@@ -137,7 +122,4 @@ export default {
     async setRestockAlertChannel(guildId, channelId, locale) {
         return getParentReply({data: 'guildTraderRestockAlertChannel', guildId: guildId, channelId: channelId, locale: locale});
     },
-    init(client) {
-        discordClient = client;
-    }
 }

--- a/modules/progress.mjs
+++ b/modules/progress.mjs
@@ -491,5 +491,4 @@ export default {
         process.on( 'SIGHUP', saveOnExit);
         progressLoaded = true;
     },
-    messageChannel,
 }

--- a/modules/shard-messenger.mjs
+++ b/modules/shard-messenger.mjs
@@ -1,0 +1,193 @@
+import { v4 as uuidv4 } from "uuid";
+import {
+    EmbedBuilder,
+} from 'discord.js';
+
+import gameData from './game-data.mjs';
+
+let shardingManager;
+let discordClient;
+
+export const getShardReply = async(shardId, message) => {
+    if (process.env.IS_SHARD) {
+        return Promise.reject(new Error('getShardReply can only be called by the parent process'));
+    }
+    message.uuid = uuidv4();
+    message.type = 'getReply';
+    return new Promise((resolve, reject) => {
+        shardingManager.shards.get(shardId).once(message.uuid, response => {
+            if (response.error) return reject(response.error);
+            resolve(response.data);
+        });
+        shardingManager.shards.get(shardId).send(message);
+    });
+};
+
+export const messageUser = async (userId, message, messageValues, shardId = 0) => {
+    if (process.env.IS_SHARD) {
+        return Promise.reject(new Error('messageUser can only be called by the parent process'));
+    }
+    return getShardReply(shardId, {data: 'messageUser', userId: userId, message: message, messageValues: messageValues}).catch(error => {
+        if (shardingManager.shards.has(shardId+1)) {
+            return messageUser(userId, message, messageValues, shardId+1);
+        }
+        return Promise.reject(error);
+    });
+};
+
+export const messageChannel = async (guildId, channelId, message, messageValues, shardId = 0) => {
+    if (process.env.IS_SHARD) {
+        return Promise.reject(new Error('messageChannel can only be called by the parent process'));
+    }
+    return getShardReply(shardId, {data: 'messageChannel', guildId: guildId, channelId: channelId, message: message, messageValues: messageValues}).catch(error => {
+        if (shardingManager.shards.has(shardId+1)) {
+            return messageChannel(guildId, channelId, message, messageValues, shardId+1);
+        }
+        return Promise.reject(error);
+    });
+}
+
+export const respondToShardMessage = async (message, shard) => {
+    //console.log(`ShardingManager received message from shard ${shard.id}`, message);
+    if (message.type === 'getReply') {
+        const response = {uuid: message.uuid};
+        try {
+            if (message.data === 'userProgress') {
+                response.data = await progress.getProgress(message.userId);
+            }
+            if (message.data === 'defaultUserProgress') {
+                response.data = await progress.getDefaultProgress();
+            }
+            if (message.data === 'safeUserProgress') {
+                response.data = await progress.getSafeProgress(message.userId);
+            }
+            if (message.data === 'userTarkovTrackerUpdateTime') {
+                response.data = await progress.getUpdateTime(message.userId);
+            }
+            if (message.data === 'setUserLevel') {
+                await progress.setLevel(message.userId, message.level);
+                response.data = message.level;
+            }
+            if (message.data === 'setUserTraderLevel') {
+                await progress.setTrader(message.userId, message.traderId, message.level);
+                response.data = message.level;
+            }
+            if (message.data === 'setUserHideoutLevel') {
+                await progress.setHideout(message.userId, message.stationId, message.level);
+                response.data = message.level;
+            }
+            if (message.data === 'setUserSkillLevel') {
+                await progress.setSkill(message.userId, message.skillId, message.level);
+                response.data = message.level;
+            }
+            if (message.data === 'userTraderRestockAlerts') {
+                response.data = await progress.getRestockAlerts(message.userId);
+            }
+            if (message.data === 'addUserTraderRestockAlert') {
+                response.data = await progress.addRestockAlert(message.userId, message.traders, message.locale);
+            }
+            if (message.data === 'removeUserTraderRestockAlert') {
+                response.data = await progress.removeRestockAlert(message.userId, message.traders, message.locale);
+            }
+            if (message.data === 'setUserTarkovTrackerToken') {
+                await progress.setToken(message.userId, message.token);
+                response.data = message.token;
+            }
+            if (message.data === 'guildTraderRestockAlertChannel') {
+                response.data = await progress.setGuildTraderRestockAlertChannel(message.guildId, message.channelId, message.locale);
+            }
+        } catch (error) {
+            response.data = null;
+            response.error = {message: error.message, stack: error.stack};
+        }
+        return shard.send(response);
+    }
+    if (message.type === 'reportIssue') {
+        shardingManager.broadcast(message);
+    }
+    if (message.uuid) {
+        shard.emit(message.uuid, message);
+    }
+};
+
+export const respondToParentMessage = async (message) => {
+    if (message.type === 'reportIssue') {
+        if (discordClient.guilds.cache.has(process.env.ISSUE_SERVER_ID)) {
+            const server = discordClient.guilds.cache.get(process.env.ISSUE_SERVER_ID);
+            const reportingChannel = server.channels.cache.get(process.env.ISSUE_CHANNEL_ID);
+    
+            if (reportingChannel) {
+                const embed = new EmbedBuilder();
+                embed.setTitle('New Issue Reported 🐞');
+                embed.setDescription(`**Issue Description:**\n${message.details}`);    
+                embed.setFooter({
+                    text: `This issue was reported by @${message.user} | ${message.reportLocation}`,
+                });
+                reportingChannel.send({
+                    embeds: [embed],
+                })
+            }
+        }
+        return;
+    }
+    if (!message.uuid) return;
+    if (message.type === 'getReply') {
+        if (message.data === 'messageUser') {
+            const t = getFi
+            const response = {uuid: message.uuid, data: {shardId: discordClient.shard.ids[0], userId: message.userId, success: false}};
+            try {
+                const user = await discordClient.users.fetch(message.userId);
+                if (!user) {
+                    throw new Error('User not found');
+                }
+                await user.send(message.message);
+                response.data.success = true;
+            } catch (error) {
+                response.error = {message: error.message, stack: error.stack};
+            }
+            discordClient.shard.send(response);
+        }
+        if (message.data === 'messageChannel') {
+            const response = {uuid: message.uuid, data: {shardId: discordClient.shard.ids[0], guildId: message.guildId, channelId: message.channelId, success: false}};
+            try {
+                const channel = await discordClient.channels.fetch(message.channelId);
+                if (!channel) {
+                    throw new Error('Channel not found');
+                }
+                if (!channel.isTextBased()) {
+                    throw new Error('Channel is not text-based');
+                }
+                await channel.send(message.message);
+                response.data.success = true;
+            } catch (error) {
+                response.error = {message: error.message, stack: error.stack};
+            }
+            discordClient.shard.send(response);
+        }
+        return;
+    }
+    process.emit(message.uuid, message);
+};
+
+export const getParentReply = async (message) => {
+    if (!process.env.IS_SHARD) {
+        return Promise.reject(new Error('getParentReply can only be called by a shard'));
+    }
+    message.uuid = uuidv4();
+    message.type = 'getReply';
+    return new Promise((resolve, reject) => {
+        process.once(message.uuid, response => {
+            if (response.error) return reject(response.error);
+            resolve(response.data);
+        });
+        discordClient.shard.send(message);
+    });
+};
+
+export function initShardMessenger(clientOrShardingManager) {
+    if (process.env.IS_SHARD) {
+        discordClient = clientOrShardingManager;
+    } else {
+        shardingManager = clientOrShardingManager;
+    }
+}

--- a/translations/de.json
+++ b/translations/de.json
@@ -5,7 +5,7 @@
         "🟢 Great": "🟢 Gut",
         "⭐ Legendary ⭐": "⭐ Legendär ⭐",
         "🔴 Poor": "🔴 Schlecht",
-        "🛒 {{trader.name}} restock in {{numMinutes}} minutes 🛒": "🛒 {{trader.name}} neue Vorräte in {{numMinutes}} Minuten 🛒",
+        "🛒 {{traderName}} restock in {{numMinutes}} minutes 🛒": "🛒 {{traderName}} neue Vorräte in {{numMinutes}} Minuten 🛒",
         "❌ ERROR ❌": "❌ Fehler ❌",
         "{{thingName}} set to {{level}}.": "{{thingName}} auf {{level}} gesetzt.",
         "A Dmg": "A Dmg",

--- a/translations/en.json
+++ b/translations/en.json
@@ -5,7 +5,7 @@
         "🟢 Great": "🟢 Great",
         "⭐ Legendary ⭐": "⭐ Legendary ⭐",
         "🔴 Poor": "🔴 Poor",
-        "🛒 {{trader.name}} restock in {{numMinutes}} minutes 🛒": "🛒 {{trader.name}} restock in {{numMinutes}} minutes 🛒",
+        "🛒 {{traderName}} restock in {{numMinutes}} minutes 🛒": "🛒 {{traderName}} restock in {{numMinutes}} minutes 🛒",
         "❌ ERROR ❌": "❌ ERROR ❌",
         "{{thingName}} set to {{level}}.": "{{thingName}} set to {{level}}.",
         "A Dmg": "A Dmg",

--- a/translations/es.json
+++ b/translations/es.json
@@ -5,7 +5,7 @@
         "🟢 Great": "🟢 Excelente",
         "⭐ Legendary ⭐": "⭐ Legendario ⭐",
         "🔴 Poor": "🔴 Pobre",
-        "🛒 {{trader.name}} restock in {{numMinutes}} minutes 🛒": "🛒 {{trader.name}} reposición en {{numMinutes}} minutos 🛒",
+        "🛒 {{traderName}} restock in {{numMinutes}} minutes 🛒": "🛒 {{traderName}} reposición en {{numMinutes}} minutos 🛒",
         "❌ ERROR ❌": "❌ ERROR ❌",
         "{{thingName}} set to {{level}}.": "{{thingName}} establecido en {{level}}.",
         "A Dmg": "Daño A",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -5,7 +5,7 @@
         "🟢 Great": "🟢 Peu Commun",
         "⭐ Legendary ⭐": "⭐ Légendaire ⭐",
         "🔴 Poor": "🔴 Mauvais",
-        "🛒 {{trader.name}} restock in {{numMinutes}} minutes 🛒": "🛒 {{trader.name}} se réapprovisionne dans {{numMinutes}} minutes 🛒",
+        "🛒 {{traderName}} restock in {{numMinutes}} minutes 🛒": "🛒 {{traderName}} se réapprovisionne dans {{numMinutes}} minutes 🛒",
         "❌ ERROR ❌": "❌ ERREUR ❌",
         "{{thingName}} set to {{level}}.": "{{thingName}} mise au niveau {{level}}.",
         "A Dmg": "A Dmg",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -5,7 +5,7 @@
         "🟢 Great": "🟢 Świetne",
         "⭐ Legendary ⭐": "⭐ Legendarne ⭐",
         "🔴 Poor": "🔴 Słabe",
-        "🛒 {{trader.name}} restock in {{numMinutes}} minutes 🛒": "🛒 {{trader.name}} uzupełni się za {{numMinutes}} minut 🛒",
+        "🛒 {{traderName}} restock in {{numMinutes}} minutes 🛒": "🛒 {{traderName}} uzupełni się za {{numMinutes}} minut 🛒",
         "❌ ERROR ❌": "❌ BŁĄD ❌",
         "{{thingName}} set to {{level}}.": "{{thingName}} ustawione na {{level}}.",
         "A Dmg": "na obrażenie",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -5,7 +5,7 @@
     "🟢 Great": "🟢 Ótimo",
     "⭐ Legendary ⭐": "⭐ Lendário ⭐",
     "🔴 Poor": "🔴 Ruim",
-    "🛒 {{trader.name}} restock in {{numMinutes}} minutes 🛒": "🛒 {{trader.name}} renova o estoque em {{numMinutes}} minutos 🛒",
+    "🛒 {{traderName}} restock in {{numMinutes}} minutes 🛒": "🛒 {{traderName}} renova o estoque em {{numMinutes}} minutos 🛒",
     "❌ ERROR ❌": "❌ ERRO ❌",
     "{{thingName}} set to {{level}}.": "{{thingName}} teve o nível definido para {{level}}.",
     "A Dmg": "Dano de A",

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -5,7 +5,7 @@
         "🟢 Great": "🟢 Лучший",
         "⭐ Legendary ⭐": "⭐ Легендарный ⭐",
         "🔴 Poor": "🔴 Плохой",
-        "🛒 {{trader.name}} restock in {{numMinutes}} minutes 🛒": "🛒 {{trader.name}} пополнит запасы через {{numMinutes}} минуты 🛒",
+        "🛒 {{traderName}} restock in {{numMinutes}} minutes 🛒": "🛒 {{traderName}} пополнит запасы через {{numMinutes}} минуты 🛒",
         "❌ ERROR ❌": "❌ ERROR ❌",
         "{{thingName}} set to {{level}}.": "{{thingName}} установил уровень {{level}}.",
         "A Dmg": "Дамаг",


### PR DESCRIPTION
Consolidates all API queries to the main module. This should reduce autocomplete timeouts for non-english requests and should also reduce the overall memory footprint since each shard no longer maintains its own copy of the game data.