### PR TITLE
Actions updates

### DIFF
--- a/.github/workflows/branch-deploy.yml
+++ b/.github/workflows/branch-deploy.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: branch-deploy
         id: branch-deploy
-        uses: github/branch-deploy@v5.2.2
+        uses: github/branch-deploy@v6.0.0
         with:
           admins: the-hideout/core-contributors
           admins_pat: ${{ secrets.BRANCH_DEPLOY_ADMINS_PAT }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: deployment check
-        uses: github/branch-deploy@v5.2.2
+        uses: github/branch-deploy@v6.0.0
         id: deployment-check
         with:
           merge_deploy_mode: "true" # tells the Action to use the merge commit workflow strategy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,8 +22,8 @@ jobs:
           merge_deploy_mode: "true" # tells the Action to use the merge commit workflow strategy
           environment: production
 
+      # always run checkout because the 'release (sentry)' step needs the code
       - name: checkout
-        if: ${{ steps.deployment-check.outputs.continue == 'true' }} # only run if the Action returned 'true' for the 'continue' output
         uses: actions/checkout@v3.5.2
 
       - uses: actions/setup-node@v3.6.0

--- a/.github/workflows/unlock-on-merge.yml
+++ b/.github/workflows/unlock-on-merge.yml
@@ -1,0 +1,20 @@
+name: Unlock On Merge
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  unlock-on-merge:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: unlock on merge
+        uses: github/branch-deploy@v6.0.0
+        id: unlock-on-merge
+        with:
+          unlock_on_merge_mode: "true" # <-- indicates that this is the "Unlock on Merge Mode" workflow
+          environment_targets: production


### PR DESCRIPTION
This pull request implements changes to the branch-deploy Action (read more here https://github.com/the-hideout/tarkov-dev/pull/517) and also fixes a bug where the main "merge CI" job would fail due to us not running `actions/checkout` if the "identical commit sha" check matched. The sentry/release Action requires the code to be "checked out" in order to publish a release (it needs the commit details).