### PR TITLE
restart - a ci job

### DIFF
--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm install
 
       # This command effectively restarts the app
-      - name: deploy to railway
+      - name: restart railway app
         run: npm run deploy
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/.github/workflows/restart.yml
+++ b/.github/workflows/restart.yml
@@ -1,0 +1,32 @@
+name: restart
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *' # runs every 6 hours at minute 0
+
+permissions:
+  contents: read
+
+jobs:
+  restart:
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3.5.3
+
+      - uses: actions/setup-node@v3.6.0
+        with:
+          node-version-file: .node-version
+          cache: 'npm'
+
+      - name: install dependencies
+        run: npm install
+
+      # This command effectively restarts the app
+      - name: deploy to railway
+        run: npm run deploy
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
# restart - a ci job

This pull request adds a new `restart` CI job. This CI job will restart the **stash** app every 6 hours at minute `0`. This workflow can also be run manually at anytime via the `actions` tab in this repository.

## Why tho?

It appears that our Discord bot has a slight memory leak. In order to reduce compute costs, and keep our bot running well, we will run this CI job several times a day to help clear out the cruft.

Railway Metrics:

<img width="478" alt="Screenshot 2023-08-05 at 10 47 46 PM" src="https://github.com/the-hideout/stash/assets/23362539/b4fbfa0f-6142-407f-8591-bded90b38f94">
