### PR TITLE
Check permissions on /restock channel

### DIFF
--- a/commands/boss.mjs
+++ b/commands/boss.mjs
@@ -107,7 +107,7 @@ const defaultFunction = {
         });
 
         let loot = Object.values(allLoot).filter(item => {
-            if (item.types.includes('noFlea')) {
+            if (item.types.includes('noFlea') && !item.types.includes('ammoBox') && !item.types.includes('ammo') && !item.normalizedName.includes('christmas-tree-ornament')) {
                 return true;
             }
         });

--- a/commands/restock.mjs
+++ b/commands/restock.mjs
@@ -87,6 +87,18 @@ const subCommands = {
                 content: `✅ ${t('Restock alert channel disabled for this server.')}`
             });
         }
+        const botMember = channel.members.find(user => user.id === interaction.client.user.id);
+        if (!botMember) {
+            return interaction.editReply({
+                content: `❌ ${t('Stash bot does not have access to #{{channelName}}.', {channelName: channel.name})}`,
+            });
+        }
+        const hasSendMessagesPermission = botMember.permissionsIn(channel) & PermissionFlagsBits.SendMessages;
+        if (!hasSendMessagesPermission) {
+            return interaction.editReply({
+                content: `❌ ${t('Stash bot does not have permission to send messages in #{{channelName}}.', {channelName: channel.name})}`,
+            });
+        }
         const locale = interaction.options.getString('locale') || 'en';
         await progress.setRestockAlertChannel(interaction.guildId, channel?.id, locale);
         return interaction.editReply({

--- a/modules/progress.mjs
+++ b/modules/progress.mjs
@@ -244,7 +244,7 @@ const startRestockAlerts = async () => {
     const setRestockTimers = async () => {
         const traders = await gameData.traders.getAll();
         // traders to skip restock timers for
-        const skipTraders = ['fence', 'lightkeeper'];
+        const skipTraders = ['fence', 'lightkeeper', 'btr-driver'];
         for (const trader of traders) {
             const currentTimer = restockTimers[trader.id];
             if (currentTimer != trader.resetTime) {

--- a/translations/en.json
+++ b/translations/en.json
@@ -102,6 +102,8 @@
         "Spawn Locations": "Spawn Locations",
         "Special Loot": "Special Loot",
         "Stash - An Escape from Tarkov Discord bot!": "Stash - An Escape from Tarkov Discord bot!",
+        "Stash bot does not have access to #{{channelName}}.": "Stash bot does not have access to #{{channelName}}.",
+        "Stash bot does not have permission to send messages in #{{channelName}}.": "Stash bot does not have permission to send messages in #{{channelName}}.",
         "Stash Invite Link": "Stash Invite Link",
         "Stash Uptime": "Stash Uptime",
         "TarkovTracker account unlinked.": "TarkovTracker account unlinked.",


### PR DESCRIPTION
When a user runs the `/restock channel` command, the bot now checks to see if it has access to and if it has permissions to send messages in the given channel.